### PR TITLE
Replace deprecated use of `bw.openDevTools`

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ app.on('ready', function() {
   mainWindow.loadUrl('file://' + __dirname + '/index.html');
 
   // Open the DevTools.
-  mainWindow.openDevTools();
+  mainWindow.webContents.openDevTools();
 
   // Emitted when the window is closed.
   mainWindow.on('closed', function() {


### PR DESCRIPTION
[Electron v0.33.4] moved `openDevTools` from `BrowserWindow` to `WebContents`

[Electron v0.33.4]: https://github.com/atom/electron/releases/tag/v0.33.4