### PR TITLE
Fix typo in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a minimal Electron application based on the [Quick Start Guide](http://electron.atom.io/docs/latest/tutorial/quick-start) within the Electron documentation.
 
-An basic Electron application needs just these files:
+A basic Electron application needs just these files:
 
 - `index.html` - A web page to render.
 - `main.js` - Starts the app and creates a browser window to render HTML.


### PR DESCRIPTION
My English teacher(s) told us that if `/^(a|e|i|o|u)/i.test(nextWord) === true`, we should use *an* instead of *a*. :joy: 

So, I guess here we need just *a basic* instead of *an basic*. :smile: 