### PR TITLE
Launch/Debug support in Visual Studio Code for Windows and OSX

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.1.0",
+    "configurations": [
+        {
+            "name": "Launch OSX",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/main.js",
+            "stopOnEntry": false,
+            "args": [],
+            "cwd": "${workspaceRoot}",
+            "runtimeExecutable": "${workspaceRoot}/node_modules/electron-prebuilt/dist/Electron.app/Contents/MacOS/Electron",
+            "runtimeArgs": [],
+            "env": {},
+            "sourceMaps": false,
+            "outDir": null
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,20 @@
             "env": {},
             "sourceMaps": false,
             "outDir": null
+        },
+        {
+            "name": "Launch Windows",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/main.js",
+            "stopOnEntry": false,
+            "args": [],
+            "cwd": "${workspaceRoot}",
+            "runtimeExecutable": "${workspaceRoot}/node_modules/electron-prebuilt/dist/electron.exe",
+            "runtimeArgs": [],
+            "env": {},
+            "sourceMaps": false,
+            "outDir": null
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,6 @@
+{
+	"version": "0.1.0",
+	"command": "npm",
+	"isShellCommand": true,
+	"args": [ "start" ]
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To clone and run this repository you'll need [Git](https://git-scm.com) and [Nod
 
 ```bash
 # Clone this repository
-git clone https://github.com/jogleasonjr/electron-quick-start
+git clone https://github.com/atom/electron-quick-start
 # Go into the repository
 cd electron-quick-start
 # Install dependencies and run the app

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To clone and run this repository you'll need [Git](https://git-scm.com) and [Nod
 
 ```bash
 # Clone this repository
-git clone https://github.com/atom/electron-quick-start
+git clone https://github.com/jogleasonjr/electron-quick-start
 # Go into the repository
 cd electron-quick-start
 # Install dependencies and run the app


### PR DESCRIPTION
In order to launch the electron-quick-start in Visual Studio Code with breakpoint debugging support in Windows and OSX, a `.vscode` directory with a `launch.json` and `tasks.json` file is needed.

I think this would be a nice addition to the quick-start template. It's much easier to grok concepts such as IPC when you can set breakpoints in the editor.